### PR TITLE
TensorFlow Datasets

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,7 +1,57 @@
+import numpy as np
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
-ds = tfds.load("cifar10", split="train", as_supervised=True)
-ds = ds.prefetch(10).take(5)
-for image, label in ds:
-    _ = 0
+# Available datasets: https://www.tensorflow.org/datasets/catalog/overview
+CIFAR10 = "cifar10"
+CIFAR100 = "cifar100"
+
+DEFAULT_NUM_DATASETS = 8
+DEFAULT_NUM_LABELS = 10
+DEFAULT_NUM_EXAMPLES = -1
+
+
+def get_random_datasets(
+    dataset: str = CIFAR100,
+    num_ds: int = DEFAULT_NUM_DATASETS,
+    num_labels: int = DEFAULT_NUM_LABELS,
+    num_ex: int = DEFAULT_NUM_EXAMPLES,
+    subset: str = "train",
+) -> list[tuple[tf.data.Dataset, np.ndarray]]:
+    """
+    Get list of dataset, label pairings.
+
+    Args:
+        dataset: Name of the TensorFlow dataset to load.
+        num_ds: Number of datasets to fetch, default is 8.
+        num_labels: Number of labels per dataset, default is 10.
+        num_ex: Number of examples within a dataset, default fetches all.
+        subset: Subset to sample from, either train (default) or test.
+
+    Returns:
+        List of tuples of dataset, labels (int).
+    """
+    full_ds = tfds.load(name=dataset, split=subset, as_supervised=True)
+    full_labels = np.fromiter(set(int(label) for _, label in full_ds), dtype=int)
+    labels = np.random.choice(full_labels, size=(num_ds, num_labels), replace=False)
+    return [
+        (
+            full_ds.filter(lambda x, y, row=i: tf.reduce_any(y == labels[row])).take(
+                num_ex
+            ),
+            labels[i],
+        )
+        for i in range(num_ds)
+    ]
+
+
+def main() -> None:
+    """Play around with code here."""
+    labelled_datasets = get_random_datasets(num_ex=200)
+    for ds, labels in labelled_datasets:
+        for image, label in ds.prefetch(10):
+            _ = 0  # Debug here
+
+
+if __name__ == "__main__":
+    main()

--- a/dataset.py
+++ b/dataset.py
@@ -22,7 +22,7 @@ def get_random_datasets(
     Get list of dataset, label pairings.
 
     Args:
-        dataset: Name of the TensorFlow dataset to load.
+        dataset: Name of the TensorFlow dataset to load, default is CIFAR 100.
         num_ds: Number of datasets to fetch, default is 8.
         num_labels: Number of labels per dataset, default is 10.
         num_ex: Number of examples within a dataset, default fetches all.

--- a/dataset.py
+++ b/dataset.py
@@ -1,0 +1,7 @@
+import tensorflow as tf
+import tensorflow_datasets as tfds
+
+ds = tfds.load("cifar10", split="train", as_supervised=True)
+ds = ds.prefetch(10).take(5)
+for image, label in ds:
+    _ = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ max-line-length = 120
 # comma-separated, and does not need to specify an error code exactly.
 # D100, D101, D102, D103, D104, D105, D106, D107: don't always need docstrings
 ignore = [
+    "B007",  # Unused locals can be useful
     "D100",
     "D101",
     "D102",
@@ -124,7 +125,7 @@ ignore = [
     "F401",  # Reduces boiler plate of making __all__ for each __init__.py
     "F403",  # Wildcard imports are convenient
     "F405",  # Wildcard imports are convenient
-    "F841",  # Unused locals are useful
+    "F841",  # Unused locals can be useful
     "W503",  # Goes against PEP8 line break before binary operator
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy
 tensorboard
 tensorflow ; platform_system!="Darwin"
 tensorflow-datasets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 tensorboard
 tensorflow ; platform_system!="Darwin"
+tensorflow-datasets
 tensorflow-macos ; platform_system=="Darwin"


### PR DESCRIPTION
Creates helper function `get_random_datasets` to get a bunch of datasets, specifying:
- Number of datasets
- Number of (random) labels per dataset
    - Labels are sampled without replacement
- Number of examples per label

The dataset used is `tfds` so one doesn't have to manually download datasets.