### PR TITLE
Checkpoints, Model Clarity, tlds_summary.csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -283,3 +283,6 @@ training/logs
 
 # Models
 models/saved_models
+
+# TLDS
+training/tlds_summary.csv

--- a/models/core.py
+++ b/models/core.py
@@ -77,36 +77,33 @@ class TransferModel(tf.keras.Model):
 
 
 class ReduceMatrix(tf.keras.Model):
-    def __init__(self, conv_filter_dim=1152, reduced_dim=32):
+    def __init__(self, conv_filter_dim: int, reduced_dim: int):
         super().__init__()
-        A_init = tf.random_normal_initializer()
         self.A = tf.Variable(
-            initial_value=A_init(
+            initial_value=tf.random_normal_initializer()(
                 shape=(1, conv_filter_dim, reduced_dim), dtype="float32"
             ),
             trainable=True,
         )
 
     def call(self, inputs, training=None, mask=None):
-        # print(">>>>input",inputs.shape)
         return tf.matmul(inputs, self.A)
 
 
 class ChoiceNetSimple(tf.keras.Model):
     def __init__(self):
         super().__init__()
-        self.layer_reduce = ReduceMatrix(conv_filter_dim=1152, reduced_dim=16)
+        self.layer_reduce = ReduceMatrix(conv_filter_dim=128 * 3 * 3, reduced_dim=16)
         self.flat = self.flatten = tf.keras.layers.Flatten()
         self.layer1 = tf.keras.layers.Dense(units=128, activation="relu")
         self.dropout = tf.keras.layers.Dropout(rate=0.3)
         self.dense = tf.keras.layers.Dense(units=1)
 
     def call(self, inputs, training=None, mask=None):
-        # =====dimention reduction for nn layers
-        x1, x2 = inputs
-        x = self.layer_reduce(x1)
+        tl_weights, ft_weights = inputs
+        x = self.layer_reduce(tl_weights)
         x = self.flat(x)
-        concat = tf.concat([x, x2], axis=1)
+        concat = tf.concat([x, ft_weights], axis=1)
         x = self.layer1(concat)
         x = self.dropout(x, training=training)
         return self.dense(x)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,12 @@ ignore_missing_imports = true
 [tool.pylint]
 # SEE: https://github.com/PyCQA/pylint/blob/master/examples/pylintrc
 
-[tool.pylint.master]
+[tool.pylint.main]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list= ["cv2"]
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.
@@ -96,6 +101,7 @@ disable = [
     "unused-variable",  # Don't care to enforce this
     "invalid-name",  # Don't care to enforce this
     "duplicate-code",  # Don't care to enforce this
+    "too-many-locals",  # Don't care to enforce this
 ]
 
 # Enable the message, report, category or checker with the given id(s).
@@ -107,6 +113,13 @@ enable = [
 
 # Maximum number of characters on a single line.
 max-line-length = 120
+
+[tool.pylint.typecheck]
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members = ["cv2"]
 
 
 [tool.flake8]

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,4 +1,5 @@
 import os
 
 # Directory where logs (e.g. TensorBoard) will be placed
-LOG_DIR = os.path.join(os.path.dirname(__file__), "logs")
+TRAINING_DIR = os.path.dirname(__file__)
+LOG_DIR = os.path.join(TRAINING_DIR, "logs")

--- a/training/create_tlds.py
+++ b/training/create_tlds.py
@@ -39,8 +39,19 @@ def train(args: argparse.Namespace) -> None:
     dataset_config = DATASET_CONFIGS[args.dataset]
 
     seed_nickname = [str(args.seed), args.run_nickname]
+    summary_fields = args.dataset, args.batch_size, args.tl_num_batches, *seed_nickname
     with open(args.tlds_csv_summary, mode="w", encoding="utf-8") as f:
-        csv.writer(f).writerow(["seed", "nickname", "labels", "loss", "accuracy"])
+        csv.writer(f).writerow(
+            [
+                "dataset",
+                "batch_size",
+                "num_batches",
+                "seed",
+                "nickname",
+                "labels",
+                "accuracy",
+            ]
+        )
 
     # NOTE: these are already batched
     ft_ds, test_ds, plants_labels = get_plant_diseases_datasets(
@@ -141,8 +152,8 @@ def train(args: argparse.Namespace) -> None:
 
         # 6. Perform predictions on the test dataset
         loss, accuracy = new_model.evaluate(test_ds)
-        with open(args.tlds_csv_summary, mode="w", encoding="utf-8") as f:
-            csv.writer(f).writerow([*seed_nickname, labels_name, loss, accuracy])
+        with open(args.tlds_csv_summary, mode="a", encoding="utf-8") as f:
+            csv.writer(f).writerow([*summary_fields, labels_name, accuracy])
 
     _ = 0  # Debug here
 


### PR DESCRIPTION
- Makes use of `tf.train.Checkpoint` to reset the transfer learning model
- Adds `training/tlds_summary.csv` to house (dataset, accuracy) pairs
- Documented 1152 size in `ChoiceNetSimple` and removed useless comments
- Moved from `x1, x2` to `tl_weights, ft_weights` to be more clear
- Adds `cv2` to `pylint` allow list of dynamic modules