### PR TITLE
ChoiceNet Training with Fine-Tuning Dataset

### DIFF
--- a/data/dataset.py
+++ b/data/dataset.py
@@ -1,6 +1,6 @@
 import os
 from collections.abc import Callable, Sequence
-from typing import NamedTuple, TypeAlias
+from typing import Literal, NamedTuple, TypeAlias
 
 import numpy as np
 import tensorflow as tf
@@ -117,6 +117,7 @@ def get_plant_diseases_datasets(
     num_train_batch: int = ALL,
     num_val_batch: int = ALL,
     seed: int = DEFAULT_SEED,
+    subset: Literal["training", "validation"] = "train",
     **from_dir_kwargs,
 ) -> tuple[tf.data.Dataset, tf.data.Dataset, list[PlantLabel]]:
     """
@@ -128,6 +129,7 @@ def get_plant_diseases_datasets(
         num_train_batch: Number of batches in the training subset, default fetches all.
         num_val_batch: Number of batches in the validation subset, default fetches all.
         seed: Seed to use for train-validation split.
+        subset: Subset (default is training) of the plant diseases dataset use.
         from_dir_kwargs: Override keyword arguments to pass through to both
             tf.keras.utils.image_dataset_from_directory calls.
 
@@ -137,8 +139,9 @@ def get_plant_diseases_datasets(
             with string labels.
     """
     from_dir_kwargs = {"seed": seed, "validation_split": 0.1} | from_dir_kwargs
+    directory: str = PLANT_DISEASES_TRAIN if subset == "train" else PLANT_DISEASES_VAL
     train_ds, val_ds = tf.keras.utils.image_dataset_from_directory(
-        PLANT_DISEASES_TRAIN, subset="both", **from_dir_kwargs
+        directory, subset="both", **from_dir_kwargs
     )
     # NOTE: indices correspond with ID, values correspond with string
     labels: list[PlantLabel] = [

--- a/training/create_tlds.py
+++ b/training/create_tlds.py
@@ -5,12 +5,14 @@ import os
 
 import tensorflow as tf
 
+from data import DATA_DIR
 from data.dataset import (
     DATASET_CONFIGS,
     DEFAULT_BATCH_SIZE,
     DEFAULT_NUM_CLASSES,
     DEFAULT_NUM_DATASETS,
     DEFAULT_SEED,
+    TRAIN_VAL_BASE_REL_PATH,
     get_plant_diseases_datasets,
     get_random_datasets,
     preprocess,
@@ -22,6 +24,9 @@ from training import LOG_DIR, TRAINING_DIR
 
 DEFAULT_CSV_SUMMARY = os.path.join(TRAINING_DIR, "tlds_summary.csv")
 TL_MODELS_SAVE_DIR = os.path.join(MODEL_SAVE_DIR, "tl_models")
+FINE_TUNE_DS_SAVE_DIR = os.path.join(
+    DATA_DIR, TRAIN_VAL_BASE_REL_PATH.split("/")[0], "ds_export"
+)
 
 
 def preprocess_standardize(
@@ -66,6 +71,8 @@ def train(args: argparse.Namespace) -> None:
         preprocess_standardize(ds, num_classes=len(plants_labels))
         for ds in (ft_ds, test_ds)
     )
+    # Save this for ChoiceNet training downstream
+    ft_ds.save(FINE_TUNE_DS_SAVE_DIR)
 
     model = TransferModel(
         input_shape=dataset_config.image_shape, num_classes=dataset_config.num_classes


### PR DESCRIPTION
- Moved from embedding transfer learning dataset to fine-tuning dataset
    - Used `Dataset.save` to persist, instead of re-reading in entirely
- Expanded `get_plant_diseases_datasets` to allow for utilization of the validation subset
