### PR TITLE
train_choicenet: Predictions

### DIFF
--- a/training/create_tlds.py
+++ b/training/create_tlds.py
@@ -71,6 +71,8 @@ def train(args: argparse.Namespace) -> None:
         preprocess_standardize(ds, num_classes=len(plants_labels))
         for ds in (ft_ds, test_ds)
     )
+    if os.path.exists(FINE_TUNE_DS_SAVE_DIR):
+        os.removedirs(FINE_TUNE_DS_SAVE_DIR)  # Only persist one dataset
     # Save this for ChoiceNet training downstream
     ft_ds.save(FINE_TUNE_DS_SAVE_DIR)
 

--- a/training/train_choicenet.py
+++ b/training/train_choicenet.py
@@ -18,7 +18,7 @@ from training.create_tlds import (
 )
 
 
-class TLDataset(tf.keras.utils.Sequence):
+class TLDSSequence(tf.keras.utils.Sequence):
     """Convert raw transfer learning dataset (TLDS) into trainable form."""
 
     @classmethod
@@ -90,13 +90,13 @@ def train(args: argparse.Namespace) -> None:
         raise ValueError(
             f"Split {args.validation_split} results in an empty test dataset."
         )
-    training_dataset = TLDataset(tlds[:num_training_ds], batch_size=args.batch_size)
-    test_dataset = TLDataset(tlds[num_training_ds:], batch_size=args.batch_size)
+    training_dataseq = TLDSSequence(tlds[:num_training_ds], batch_size=args.batch_size)
+    test_dataseq = TLDSSequence(tlds[num_training_ds:], batch_size=args.batch_size)
 
-    model.fit(training_dataset)
-    preds: np.ndarray = model.predict(test_dataset)
+    model.fit(training_dataseq)
+    preds: np.ndarray = model.predict(test_dataseq)
     accuracies: list[np.ndarray] = [
-        test_dataset.get_accuracies(i) for i in range(len(test_dataset))
+        test_dataseq.get_accuracies(i) for i in range(len(test_dataseq))
     ]
     _ = 0  # Debug here
 

--- a/training/train_choicenet.py
+++ b/training/train_choicenet.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 import tensorflow as tf
 
-from data.dataset import DATASET_CONFIGS, DEFAULT_SEED
+from data.dataset import DATASET_CONFIGS, DEFAULT_BATCH_SIZE, DEFAULT_SEED
 from embedding.embed import embed_dataset, embed_model
 from models.core import ChoiceNetSimple, TransferModel
 from training import LOG_DIR
@@ -47,6 +47,11 @@ class TLDataset(tf.keras.utils.Sequence):
         bslice = slice(idx * self.batch_size, (idx + 1) * self.batch_size)
         return (self.arrays[0][bslice], self.arrays[1][bslice]), self.arrays[2][bslice]
 
+    def get_accuracies(self, idx: int) -> np.ndarray:
+        """Get only the dataset's accuracies for the input batch index."""
+        bslice = slice(idx * self.batch_size, (idx + 1) * self.batch_size)
+        return self.arrays[2][bslice]
+
 
 def train(args: argparse.Namespace) -> None:
     tf.random.set_seed(args.seed)
@@ -79,8 +84,16 @@ def train(args: argparse.Namespace) -> None:
         loss="mse",
         metrics=["mse"],
     )
-    sequence = TLDataset(tlds)  # TODO: make batch_size an arg
-    model.fit(sequence)
+
+    num_training_ds = int(len(tlds) * (1 - args.validation_split))
+    training_dataset = TLDataset(tlds[:num_training_ds], batch_size=args.batch_size)
+    test_dataset = TLDataset(tlds[num_training_ds:], batch_size=args.batch_size)
+
+    model.fit(training_dataset)
+    preds: np.ndarray = model.predict(test_dataset)
+    accuracies: list[np.ndarray] = [
+        test_dataset.get_accuracies(i) for i in range(len(test_dataset))
+    ]
     _ = 0  # Debug here
 
 
@@ -103,6 +116,18 @@ def main() -> None:
     )
     parser.add_argument(
         "--learning_rate", type=float, default=1e-3, help="learning rate"
+    )
+    parser.add_argument(
+        "--validation_split",
+        type=float,
+        default=0.3,
+        help="fraction of transfer learning datasets to use for validation",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help="batch size for training and prediction",
     )
     parser.add_argument(
         "--log_dir", type=str, default=LOG_DIR, help="log base directory"

--- a/training/train_choicenet.py
+++ b/training/train_choicenet.py
@@ -86,6 +86,10 @@ def train(args: argparse.Namespace) -> None:
     )
 
     num_training_ds = int(len(tlds) * (1 - args.validation_split))
+    if num_training_ds >= len(tlds):
+        raise ValueError(
+            f"Split {args.validation_split} results in an empty test dataset."
+        )
     training_dataset = TLDataset(tlds[:num_training_ds], batch_size=args.batch_size)
     test_dataset = TLDataset(tlds[num_training_ds:], batch_size=args.batch_size)
 


### PR DESCRIPTION
- Renamed `TLDataset` to `TLDSSequence` for clarity
- Added `validation_split` arg and predictions on held-out data with `ChoiceNetSimple`
- Added removal of saved fine-tuning datasets
    - Prevents case where we save several datasets made by different arguments
- Added `batch_size` arg for TLDS
