### PR TITLE
Similar and Dissimilar Datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,3 +288,4 @@ models/saved_models/
 # TLDS
 training/tlds/
 training/tlds_summary.csv
+training/choicenet_performance.png

--- a/models/core.py
+++ b/models/core.py
@@ -71,9 +71,9 @@ class TransferModel(tf.keras.Model):
         """
         with tempfile.NamedTemporaryFile(suffix=".h5") as fp:
             self.save_weights(fp.name)
-            input_shape = self.input_layer.input_shape[0]
+            (input_shape,) = self.input_layer.input_shape
             copied_model = type(self)(
-                input_shape=input_shape,
+                input_shape=input_shape[1:],  # Leave off batch dimension
                 num_classes=self.dense.units,
             )
             copied_model.build(input_shape=input_shape)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 kaggle
+matplotlib
 numpy
 opencv-python
 scikit-learn

--- a/training/create_tlds.py
+++ b/training/create_tlds.py
@@ -46,7 +46,7 @@ def preprocess_standardize(
 ) -> tf.data.Dataset:
     """Standardize images, convert labels to one-hot vector, and prefetch."""
 
-    def image_preprocessor(image):
+    def image_preprocessor(image: tf.Tensor) -> tf.Tensor:
         if image_size is not None and image.shape != image_size:
             if len(image_size) == 4:
                 _, h, w, _ = image_size
@@ -54,9 +54,7 @@ def preprocess_standardize(
                 h, w, _ = image_size
             else:
                 raise NotImplementedError(f"Unimplemented shape {image_size}.")
-            image = tf.image.resize_with_crop_or_pad(
-                image, target_height=h, target_width=w
-            )
+            image = tf.image.resize(image, target_height=h, target_width=w)
         return tf.image.per_image_standardization(image)
 
     return preprocess(


### PR DESCRIPTION
Dataset utilities:
- Adds [`plant_village`](https://www.tensorflow.org/datasets/catalog/plant_village) (similar) bird species (dissimilar) to dataset configs
- Makes batching optional
- Moved to functions accepting `tf.data.Dataset` instead of dataset `str` names

TLDS creation and ChoiceNet training
- Moves back to fine-tuning only on the plant leafs dataset
- Adds auto-resizing to `preprocess_standardize`
- Uses `plant_village` and bird species to make 3 similar and 3 dissimilar datasets
- Adds plotting of ChoiceNet training results with unit line

Model:
- Fixed a bug where `TransferModel.clone` was appending an extra batch `None` dimension