### PR TITLE
Plant Leaves Dataset, v1 in ChoiceNet Naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,6 +277,7 @@ fabric.properties
 
 # Datasets
 data/plant-diseases/
+data/plant-leaves/
 data/bird-species/
 
 # Logs
@@ -288,4 +289,4 @@ models/saved_models/
 # TLDS
 training/tlds/
 training/tlds_summary.csv
-training/choicenet_performance.png
+training/choicenet_v1_performance.png

--- a/README.md
+++ b/README.md
@@ -4,17 +4,21 @@
 
 ## Datasets
 
-We used two datasets from Kaggle:
+We used a few datasets from Kaggle:
 
 - [New Plant Diseases Dataset][2]:
   256 x 256 RGB JPG images of healthy and unhealthy crop leaves
+  - Replaced with [TensorFlow Datasets `plant_village` dataset][5]
+- [Plant Leaves for Image Classification][4]:
+  6000 x 4000 RGB JPG images of healthy and unhealthy leaves from 12 plants
 - [BIRDS 450 SPECIES- IMAGE CLASSIFICATION][3]:
   224 x 224 RGB JPG images of bird species
 
-Here's how to easily download both with the Kaggle API:
+Here's how to easily download them all with the Kaggle API:
 
 ```bash
 kaggle datasets download -p data/plant-diseases --unzip vipoooool/new-plant-diseases-dataset
+kaggle datasets download -p data/plant-diseases --unzip csafrit2/plant-leaves-for-image-classification
 kaggle datasets download -p data/bird-species --unzip gpiosenka/100-bird-species
 ```
 
@@ -81,3 +85,5 @@ Finally, need to rund td_predict
 [1]: https://cs330.stanford.edu/
 [2]: https://www.kaggle.com/datasets/vipoooool/new-plant-diseases-dataset
 [3]: https://www.kaggle.com/datasets/gpiosenka/100-bird-species
+[4]: https://www.kaggle.com/datasets/csafrit2/plant-leaves-for-image-classification
+[5]: https://www.tensorflow.org/datasets/catalog/plant_village

--- a/data/dataset.py
+++ b/data/dataset.py
@@ -25,7 +25,7 @@ DATASET_CONFIGS: dict[str, DatasetMetadata] = {
     "cifar100": DatasetMetadata("cifar100", 100, (32, 32, 3)),
     "bird-species": DatasetMetadata("bird-species", 450, (256, 256, 3)),
     "plant_village": DatasetMetadata("plant_village", 38, (256, 256, 3)),
-    "plant-leaves": DatasetMetadata("plant-leaves", 2, (6000, 4000, 3)),
+    "plant-leaves": DatasetMetadata("plant-leaves", 22, (6000, 4000, 3)),
 }
 
 DEFAULT_SEED = 42

--- a/data/dataset.py
+++ b/data/dataset.py
@@ -25,6 +25,7 @@ DATASET_CONFIGS: dict[str, DatasetMetadata] = {
     "cifar100": DatasetMetadata("cifar100", 100, (32, 32, 3)),
     "bird-species": DatasetMetadata("bird-species", 450, (256, 256, 3)),
     "plant_village": DatasetMetadata("plant_village", 38, (256, 256, 3)),
+    "plant-leaves": DatasetMetadata("plant-leaves", 2, (6000, 4000, 3)),
 }
 
 DEFAULT_SEED = 42
@@ -114,9 +115,6 @@ PLANT_DISEASES_TRAIN = os.path.join(
 PLANT_DISEASES_VAL = os.path.join(
     DATA_DIR, *PLANT_DISEASES_REL_PATH.split("/"), "valid"
 )
-BIRD_SPECIES_REL_PATH = "bird-species"
-BIRD_SPECIES_TRAIN = os.path.join(DATA_DIR, *BIRD_SPECIES_REL_PATH.split("/"), "train")
-BIRD_SPECIES_VAL = os.path.join(DATA_DIR, *BIRD_SPECIES_REL_PATH.split("/"), "valid")
 
 
 def get_image_dataset_from_directory(
@@ -194,6 +192,42 @@ def get_plant_diseases_datasets(
         PlantLabel(raw_label, *raw_label.split("___")) for raw_label in raw_labels
     ]
     return train_ds, val_ds, labels
+
+
+PLANT_LEAVES_REL_PATH = "plant-leaves/Plants_2"
+PLANT_LEAVES_TRAIN = os.path.join(DATA_DIR, *PLANT_LEAVES_REL_PATH.split("/"), "train")
+PLANT_LEAVES_VAL = os.path.join(DATA_DIR, *PLANT_LEAVES_REL_PATH.split("/"), "valid")
+
+
+def get_plant_leaves_datasets(
+    num_train_batch: int = ALL,
+    num_val_batch: int = ALL,
+    seed: int = DEFAULT_SEED,
+    **from_dir_kwargs,
+) -> tuple[tf.data.Dataset, tf.data.Dataset, list[str]]:
+    """
+    Get the training and validation subsets of the plant leaves dataset.
+
+    SEE: https://www.kaggle.com/datasets/csafrit2/plant-leaves-for-image-classification
+
+    Returns:
+        Tuple of training dataset, validation dataset, labels.
+            NOTE: for labels, indices correspond with ID, values correspond
+            with string labels.
+    """
+    return get_image_dataset_from_directory(
+        train_dir=PLANT_LEAVES_TRAIN,
+        val_dir=PLANT_LEAVES_VAL,
+        num_train_batch=num_train_batch,
+        num_val_batch=num_val_batch,
+        seed=seed,
+        **from_dir_kwargs,
+    )
+
+
+BIRD_SPECIES_REL_PATH = "bird-species"
+BIRD_SPECIES_TRAIN = os.path.join(DATA_DIR, *BIRD_SPECIES_REL_PATH.split("/"), "train")
+BIRD_SPECIES_VAL = os.path.join(DATA_DIR, *BIRD_SPECIES_REL_PATH.split("/"), "valid")
 
 
 def get_bird_species_datasets(

--- a/models/core.py
+++ b/models/core.py
@@ -100,7 +100,7 @@ class ReduceMatrix(tf.keras.Model):
         return tf.matmul(inputs, self.A)
 
 
-class ChoiceNetSimple(tf.keras.Model):
+class ChoiceNetv1(tf.keras.Model):
     REDUCE_FILTER_DIM = TransferModel.LAYER_3_NUM_FILTERS * math.prod(
         TransferModel.KERNEL_SIZE
     )

--- a/training/choicenet.py
+++ b/training/choicenet.py
@@ -5,7 +5,7 @@ import numpy as np
 import tensorflow as tf
 
 from embedding.td_pre_process_weight import get_weight_matrix_input
-from models.core import ChoiceNetSimple
+from models.core import ChoiceNetv1
 from training import LOG_DIR
 
 
@@ -26,7 +26,7 @@ def train_model(args):
     Y_train = Y_weight[:2]
     Y_val = Y_weight[2:3]
 
-    model = ChoiceNetSimple()
+    model = ChoiceNetv1()
 
     opt = tf.keras.optimizers.Adam(learning_rate=learning_rate)
     model.compile(

--- a/training/create_tlds.py
+++ b/training/create_tlds.py
@@ -18,10 +18,11 @@ from data.dataset import (
     DEFAULT_NUM_DATASETS,
     DEFAULT_SEED,
     PLANT_DISEASES_REL_PATH,
+    PLANT_LEAVES_REL_PATH,
     Shape,
     get_bird_species_datasets,
     get_dataset_subset,
-    get_plant_diseases_datasets,
+    get_plant_leaves_datasets,
     get_random_datasets,
     preprocess,
 )
@@ -32,6 +33,9 @@ from training import LOG_DIR, TLDS_DIR, TRAINING_DIR
 DEFAULT_CSV_SUMMARY = os.path.join(TRAINING_DIR, "tlds_summary.csv")
 PLANT_DISEASES_TRAIN_SAVE_DIR = os.path.join(
     DATA_DIR, *PLANT_DISEASES_REL_PATH.split("/"), "train_ds_export"
+)
+PLANT_LEAVES_TRAIN_SAVE_DIR = os.path.join(
+    DATA_DIR, *PLANT_LEAVES_REL_PATH.split("/"), "train_ds_export"
 )
 BIRD_SPECIES_TRAIN_SAVE_DIR = os.path.join(
     DATA_DIR, *BIRD_SPECIES_REL_PATH.split("/"), "train_ds_export"
@@ -51,7 +55,7 @@ def preprocess_standardize(
             if len(image_size) == 4:
                 _, *hw, _ = image_size
             elif len(image_size) == 3:
-                hw, _ = image_size
+                *hw, _ = image_size
             else:
                 raise NotImplementedError(f"Unimplemented shape {image_size}.")
             image = tf.image.resize(image, size=hw)
@@ -83,7 +87,7 @@ def train(args: argparse.Namespace) -> None:
         csv.writer(f).writerow(["dataset", "seed", "labels", "accuracy"])
 
     dataset_config = DATASET_CONFIGS[args.dataset]
-    plants_ft_ds, plants_test_ds, plants_labels = get_plant_diseases_datasets(
+    plants_ft_ds, plants_test_ds, plants_labels = get_plant_leaves_datasets(
         num_train_batch=args.ft_num_batches,
         num_val_batch=args.test_num_batches,
         seed=args.seed,
@@ -94,7 +98,7 @@ def train(args: argparse.Namespace) -> None:
         plants_ft_ds,
         plants_test_ds,
         preprocessor=partial(preprocess_standardize, num_classes=len(plants_labels)),
-        ft_ds_save_dir=PLANT_DISEASES_TRAIN_SAVE_DIR,
+        ft_ds_save_dir=PLANT_LEAVES_TRAIN_SAVE_DIR,
     )
 
     def compute_accuracy(tl_model: TransferModel) -> float:
@@ -265,7 +269,7 @@ def main() -> None:
     parser.add_argument(
         "--ft_num_batches",
         type=int,
-        default=math.ceil(2e3 / DEFAULT_BATCH_SIZE),
+        default=math.ceil(1e3 / DEFAULT_BATCH_SIZE),
         help="number of batches to have in the fine tuning dataset",
     )
     parser.add_argument(
@@ -277,7 +281,7 @@ def main() -> None:
     parser.add_argument(
         "--test_num_batches",
         type=int,
-        default=math.ceil(1e3 / DEFAULT_BATCH_SIZE),
+        default=math.ceil(500 / DEFAULT_BATCH_SIZE),
         help="number of batches to have in the test dataset",
     )
     parser.add_argument("--num_epochs", type=int, default=15, help="number of epochs")

--- a/training/td_predict.py
+++ b/training/td_predict.py
@@ -4,7 +4,7 @@ import numpy as np
 import tensorflow as tf
 
 from embedding.embed import embed_model
-from models.core import ChoiceNetSimple, TransferModel
+from models.core import ChoiceNetv1, TransferModel
 
 
 def get_weight_matrix_input_predict(fine_tune_weights: str):
@@ -38,7 +38,7 @@ def predict(args):
     print(">>>>your fist", X_test.shape)
     print(">>>>your 2nd X", X_test2.shape)
 
-    model = ChoiceNetSimple()
+    model = ChoiceNetv1()
     checkpoint = tf.train.Checkpoint(model)
     checkpoint.restore(choice_net_weights).expect_partial()
 

--- a/training/td_train.py
+++ b/training/td_train.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 import numpy as np
 import tensorflow as tf
 
-from models.core import ChoiceNetSimple
+from models.core import ChoiceNetv1
 
 
 def train_model(args):
@@ -29,7 +29,7 @@ def train_model(args):
     Y_val = Y_matrix[-1:]
     X_val2 = X_input2[-1:]
 
-    model = ChoiceNetSimple()
+    model = ChoiceNetv1()
 
     opt = tf.keras.optimizers.Adam(learning_rate=args.learning_rate)
     model.compile(

--- a/training/train_choicenet_v1.py
+++ b/training/train_choicenet_v1.py
@@ -15,7 +15,7 @@ from data.dataset import DATASET_CONFIGS, DEFAULT_BATCH_SIZE, DEFAULT_SEED
 from embedding.embed import embed_dataset, embed_model
 from models.core import ChoiceNetv1, TransferModel
 from training import LOG_DIR, TLDS_DIR
-from training.create_tlds import DEFAULT_CSV_SUMMARY, PLANT_DISEASES_TRAIN_SAVE_DIR
+from training.create_tlds import DEFAULT_CSV_SUMMARY, PLANT_LEAVES_TRAIN_SAVE_DIR
 
 TLDataset: TypeAlias = list[tuple[str, tuple[np.ndarray, np.ndarray], float]]
 
@@ -24,7 +24,7 @@ def build_raw_tlds(
     summary_path: str,
 ) -> TLDataset:
     """Build a raw version of the transfer-learning dataset."""
-    plants_ft_ds = tf.data.Dataset.load(PLANT_DISEASES_TRAIN_SAVE_DIR)
+    plants_ft_ds = tf.data.Dataset.load(PLANT_LEAVES_TRAIN_SAVE_DIR)
     embedded_plants_ft_ds = embed_dataset(plants_ft_ds)
 
     tlds: TLDataset = []

--- a/training/train_choicenet_v1.py
+++ b/training/train_choicenet_v1.py
@@ -13,7 +13,7 @@ import tensorflow as tf
 
 from data.dataset import DATASET_CONFIGS, DEFAULT_BATCH_SIZE, DEFAULT_SEED
 from embedding.embed import embed_dataset, embed_model
-from models.core import ChoiceNetSimple, TransferModel
+from models.core import ChoiceNetv1, TransferModel
 from training import LOG_DIR, TLDS_DIR
 from training.create_tlds import DEFAULT_CSV_SUMMARY, PLANT_DISEASES_TRAIN_SAVE_DIR
 
@@ -110,7 +110,7 @@ def train_test(args: argparse.Namespace) -> None:
         )
         test_dataseq = TLDSSequence(tlds[num_training_ds:], batch_size=args.batch_size)
 
-    model = ChoiceNetSimple()
+    model = ChoiceNetv1()
     model.compile(
         optimizer=tf.keras.optimizers.Adam(learning_rate=args.learning_rate),
         loss="mse",
@@ -148,12 +148,12 @@ def train_test(args: argparse.Namespace) -> None:
     ax.grid()
     ax.legend()
     fig.tight_layout()
-    fig.savefig("choicenet_performance.png")
+    fig.savefig("choicenet_v1_performance.png")
     _ = 0  # Debug here
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Train ChoiceNet")
+    parser = argparse.ArgumentParser(description="Train ChoiceNet v1")
     parser.add_argument(
         "-s", "--seed", type=int, default=DEFAULT_SEED, help="random seed"
     )


### PR DESCRIPTION
- Integrates [Plant Leaves for Image Classification](https://www.kaggle.com/datasets/csafrit2/plant-leaves-for-image-classification) dataset into `REAMDE`, `.gitignore`, and dataset helpers
- Fixes unpacking of `image_size` in create TLDS's `image_preprocessor`


Also, renames the training of ChoiceNet to use v1 terminology