### PR TITLE
ImageNet as random dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here's how to easily download them all with the Kaggle API:
 
 ```bash
 kaggle datasets download -p data/plant-diseases --unzip vipoooool/new-plant-diseases-dataset
-kaggle datasets download -p data/plant-diseases --unzip csafrit2/plant-leaves-for-image-classification
+kaggle datasets download -p data/plant-leaves --unzip csafrit2/plant-leaves-for-image-classification
 kaggle datasets download -p data/bird-species --unzip gpiosenka/100-bird-species
 ```
 

--- a/training/create_tlds.py
+++ b/training/create_tlds.py
@@ -15,7 +15,6 @@ from data.dataset import (
     DATASET_CONFIGS,
     DEFAULT_BATCH_SIZE,
     DEFAULT_NUM_CLASSES,
-    DEFAULT_NUM_DATASETS,
     DEFAULT_SEED,
     PLANT_DISEASES_REL_PATH,
     PLANT_LEAVES_REL_PATH,
@@ -154,14 +153,14 @@ def train(args: argparse.Namespace) -> None:
     }
     cifar100_random_datasets = get_random_datasets(
         dataset=tfds.load(name="cifar100", split="train", as_supervised=True),
-        num_ds=args.tl_num_random_datasets,
+        num_ds=args.tl_num_random_cifar100_datasets,
         **kwargs,
     )
     imagenet_random_datasets = get_random_datasets(
         dataset=tfds.load(
             name="imagenet_resized/32x32", split="train", as_supervised=True
         ),
-        num_ds=args.tl_num_random_datasets,
+        num_ds=args.tl_num_random_imagenet_datasets,
         **kwargs,
     )
     plants_village_datasets = get_random_datasets(
@@ -238,10 +237,16 @@ def main() -> None:
         help="batch size during transfer learning, fine tuning, and prediction",
     )
     parser.add_argument(
-        "--tl_num_random_datasets",
+        "--tl_num_random_cifar100_datasets",
         type=int,
-        default=DEFAULT_NUM_DATASETS,
-        help="number of random_transfer learning datasets to sample",
+        default=10,
+        help="number of random transfer learning datasets to sample from CIFAR100",
+    )
+    parser.add_argument(
+        "--tl_num_random_imagenet_datasets",
+        type=int,
+        default=30,
+        help="number of random transfer learning datasets to sample from ImageNet",
     )
     parser.add_argument(
         "--tl_num_similar_datasets",

--- a/training/create_tlds.py
+++ b/training/create_tlds.py
@@ -269,7 +269,7 @@ def main() -> None:
     parser.add_argument(
         "--tl_num_batches",
         type=int,
-        default=math.ceil(15e3 / DEFAULT_BATCH_SIZE),
+        default=math.ceil(5e3 / DEFAULT_BATCH_SIZE),
         help="number of batches to have in each transfer learning dataset",
     )
     parser.add_argument(

--- a/training/train_choicenet_v1.py
+++ b/training/train_choicenet_v1.py
@@ -31,7 +31,7 @@ def build_raw_tlds(
     with open(summary_path, encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for i, row in enumerate(reader):
-            dataset_name = row["dataset"]
+            dataset_name: str = row["dataset"]
             if i == 0:
                 dataset_config = DATASET_CONFIGS[dataset_name]
                 model = TransferModel(
@@ -40,7 +40,9 @@ def build_raw_tlds(
                 )
             try:
                 tl_model_folder = ",".join(map(str, json.loads(row["labels"])))
-                if dataset_name == "cifar100":
+                if dataset_name == "cifar100" or dataset_name.startswith(
+                    "imagenet_resized"
+                ):
                     label = "random"
                 elif dataset_name == "bird-species":
                     label = "dissimilar"


### PR DESCRIPTION
- Hardcoded ImageNet and CIFAR100 in `create_tlds.py` and `train_choicenet_v1.py`
- Made ImageNet generate 30 random datasets
- Decreased number of TL images from 15000 to 5000
- Fixed a typo in `README.md` on `plant-leaves` dataset