### PR TITLE
TransferModel Head Size 10

### DIFF
--- a/data/dataset.py
+++ b/data/dataset.py
@@ -300,19 +300,17 @@ def split(
 
 def preprocess(
     dataset: tf.data.Dataset,
-    num_classes: int = DEFAULT_NUM_CLASSES,
     image_preprocessor: Callable[[tf.Tensor], tf.Tensor] | None = None,
+    label_preprocessor: Callable[[tf.Tensor], tf.Tensor] | None = None,
 ) -> tf.data.Dataset:
     """
     Preprocess the input dataset for training.
 
     Args:
         dataset: Dataset to preprocess.
-        num_classes: Number of classes present in the dataset.
-        image_preprocessor: Function to pre-process images per a model's requirements.
-            Default of None will not try to pre-process images.
-            Examples:
-            - VGG16: tf.keras.applications.vgg16.preprocess_input.
+        image_preprocessor: Function to pre-process images.
+            Example for VGG16: tf.keras.applications.vgg16.preprocess_input.
+        label_preprocessor: Optional function to pre-process labels.
 
     Returns:
         Preprocessed dataset.
@@ -321,9 +319,9 @@ def preprocess(
     def _preprocess(x: tf.Tensor, y: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor]:
         if image_preprocessor is not None:
             x = image_preprocessor(x)
-        # NOTE: one_hot is a transformation step for Tensors, so we use it here
-        # over to_categorical
-        return x, tf.one_hot(y, depth=num_classes)
+        if label_preprocessor is not None:
+            y = label_preprocessor(y)
+        return x, y
 
     return dataset.map(_preprocess)
 

--- a/training/create_tlds.py
+++ b/training/create_tlds.py
@@ -60,9 +60,12 @@ def preprocess_standardize(
             image = tf.image.resize(image, size=hw)
         return tf.image.per_image_standardization(image)
 
-    return preprocess(
-        ds, num_classes=num_classes, image_preprocessor=image_preprocessor
-    ).prefetch(prefetch_size)
+    def label_preprocessor(label: tf.Tensor) -> tf.Tensor:
+        return tf.one_hot(label, depth=num_classes)
+
+    return preprocess(ds, image_preprocessor, label_preprocessor).prefetch(
+        prefetch_size
+    )
 
 
 def preprocess_ds_save(


### PR DESCRIPTION
- When using ImageNet, there are 1000 classes, which requires head size to be 1000
- We are only using 10 classes per dataset

This PR enables remapping of labels (via a `labels_preprocessor`) on a per-dataset basis to be from `[367,633,117,434,78,542,451,464,79,46]` to `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`.  This enables our final `Dense` layer to be size 10.
- Removes hardcoding of labels preprocessor from `tf.one_hot` to be a passed function
- Uses `tf.lookup.KeyValueTensorInitializer` + `tf.lookup.StaticHashTable` for the mapping
- Removes all `dataset_subset` calls and instead works with datasets directly
- Makes `TransferModel` head size during transfer learning to be 10

This PR completes the integration of ImageNet