### PR TITLE
ChoiceNet v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -290,3 +290,4 @@ models/saved_models/
 training/tlds/
 training/tlds_summary.csv
 training/choicenet_v1_performance.png
+training/choicenet_v2_performance.png

--- a/embedding/embed.py
+++ b/embedding/embed.py
@@ -31,7 +31,7 @@ def embed_model(model: TransferModel) -> np.ndarray:
 DEFAULT_PCA_NUM_COMPONENTS = 256
 
 
-def embed_dataset(
+def embed_dataset_pca(
     dataset: np.ndarray | tf.data.Dataset,
     pca_num_components: int = DEFAULT_PCA_NUM_COMPONENTS,
 ) -> np.ndarray:
@@ -60,12 +60,12 @@ def get_npy_paths(path: str) -> list[str]:
 def pca_dataset(path: str) -> None:
     all_data_list = []
     for data_path in get_npy_paths(path):
-        all_data_list.append(embed_dataset(dataset=np.load(data_path)))
+        all_data_list.append(embed_dataset_pca(dataset=np.load(data_path)))
     np.save(os.path.join(path, "data.npy"), np.array(all_data_list))
 
 
 def pca_single_dataset(path: str, num_repeats: int = 1) -> np.ndarray:
-    x_average = embed_dataset(dataset=np.load(path))
+    x_average = embed_dataset_pca(dataset=np.load(path))
     return np.repeat(x_average[np.newaxis, :], repeats=num_repeats, axis=0)
 
 

--- a/models/core.py
+++ b/models/core.py
@@ -57,11 +57,13 @@ class TransferModel(tf.keras.Model):
         self.dropout = tf.keras.layers.Dropout(rate=0.3)
         self.dense = tf.keras.layers.Dense(units=num_classes, activation="softmax")
 
-    def call(self, inputs, training=None, mask=None):
+    def call(self, inputs, training=None, mask=None, include_top: bool = True):
         x = self.input_layer(inputs)
         x = self.layer1(x)
         x = self.layer2(x)
         x = self.layer3(x)
+        if not include_top:  # Hack to get layer 3 activations
+            return x
         x = self.pooling(x)
         x = self.flatten(x)
         x = self.dropout(x, training=training)

--- a/models/core.py
+++ b/models/core.py
@@ -35,13 +35,22 @@ class TransferModel(tf.keras.Model):
         # Include input_layer so we can infer input shape for copy
         self.input_layer = tf.keras.layers.InputLayer(input_shape)
         self.layer1 = Conv2D(
-            filters=self.LAYER_1_NUM_FILTERS, kernel_size=self.KERNEL_SIZE, strides=2
+            name="conv2d_1",
+            filters=self.LAYER_1_NUM_FILTERS,
+            kernel_size=self.KERNEL_SIZE,
+            strides=2,
         )
         self.layer2 = Conv2D(
-            filters=self.LAYER_2_NUM_FILTERS, kernel_size=self.KERNEL_SIZE, strides=2
+            name="conv2d_2",
+            filters=self.LAYER_2_NUM_FILTERS,
+            kernel_size=self.KERNEL_SIZE,
+            strides=2,
         )
         self.layer3 = Conv2D(
-            filters=self.LAYER_3_NUM_FILTERS, kernel_size=self.KERNEL_SIZE, strides=2
+            name="conv2d_3",
+            filters=self.LAYER_3_NUM_FILTERS,
+            kernel_size=self.KERNEL_SIZE,
+            strides=2,
         )
         self.pooling = tf.keras.layers.MaxPooling2D(pool_size=(2, 2))
         self.flatten = tf.keras.layers.Flatten()

--- a/models/core.py
+++ b/models/core.py
@@ -134,3 +134,31 @@ class ChoiceNetv1(tf.keras.Model):
         x = self.layer1(concat)
         x = self.dropout(x, training=training)
         return self.dense(x)
+
+
+class ChoiceNetv2(tf.keras.Model):
+    MODEL_REDUCE_DIM = TransferModel.LAYER_3_NUM_FILTERS * math.prod(
+        TransferModel.KERNEL_SIZE
+    )
+    RESNET50V2_BEFORE_TOP_DIM = 2048
+
+    def __init__(self):
+        super().__init__()
+        self.weights_reduce = ReduceMatrix(
+            conv_filter_dim=self.MODEL_REDUCE_DIM, reduced_dim=256
+        )
+        self.dataset_reduce = ReduceMatrix(
+            conv_filter_dim=self.RESNET50V2_BEFORE_TOP_DIM, reduced_dim=256
+        )
+        self.flatten = tf.keras.layers.Flatten()
+        self.dense1 = tf.keras.layers.Dense(units=128, activation="relu")
+        self.dropout = tf.keras.layers.Dropout(rate=0.3)
+        self.dense2 = tf.keras.layers.Dense(units=1)
+
+    def call(self, inputs: Annotated[Sequence[tf.Tensor], 2], training=None, mask=None):
+        reduced_tl_model_weights = self.weights_reduce(inputs[0])
+        reduced_ft_dataset_weights = self.dataset_reduce(inputs[1])
+        x = self.flatten(reduced_tl_model_weights - reduced_ft_dataset_weights)
+        x = self.dense1(x)
+        x = self.dropout(x, training=training)
+        return self.dense2(x)

--- a/training/train_choicenet_v1.py
+++ b/training/train_choicenet_v1.py
@@ -18,7 +18,7 @@ from data.dataset import (
     DEFAULT_NUM_CLASSES,
     DEFAULT_SEED,
 )
-from embedding.embed import embed_dataset, embed_model
+from embedding.embed import embed_dataset_pca, embed_model
 from models.core import ChoiceNetv1, TransferModel
 from training import LOG_DIR, TLDS_DIR
 from training.create_tlds import DEFAULT_CSV_SUMMARY, PLANT_LEAVES_TRAIN_SAVE_DIR
@@ -70,7 +70,7 @@ def build_raw_tlds(
 ) -> TLDataset:
     """Build a raw version of the transfer-learning dataset."""
     plants_ft_ds = tf.data.Dataset.load(PLANT_LEAVES_TRAIN_SAVE_DIR)
-    embedded_plants_ft_ds = embed_dataset(plants_ft_ds)
+    embedded_plants_ft_ds = embed_dataset_pca(plants_ft_ds)
 
     tlds: TLDataset = []
     for tl_model, _, ds_nickname, accuracy in parse_summary(summary_path, num_classes):

--- a/training/train_choicenet_v1.py
+++ b/training/train_choicenet_v1.py
@@ -26,7 +26,7 @@ TLDataset: TypeAlias = list[tuple[str, tuple[np.ndarray, np.ndarray], float]]
 
 
 def build_raw_tlds(
-    summary_path: str, num_classes: int = DEFAULT_NUM_CLASSES
+    summary_path: str = DEFAULT_CSV_SUMMARY, num_classes: int = DEFAULT_NUM_CLASSES
 ) -> TLDataset:
     """Build a raw version of the transfer-learning dataset."""
     plants_ft_ds = tf.data.Dataset.load(PLANT_LEAVES_TRAIN_SAVE_DIR)
@@ -58,10 +58,12 @@ def build_raw_tlds(
             except json.decoder.JSONDecodeError:
                 tl_model_folder = row["labels"]
                 label = "rand init"
-            weights_path = os.path.join(
-                TLDS_DIR, row["seed"], dataset_name, tl_model_folder, "tl_model"
+            saved_path = os.path.join(
+                TLDS_DIR, row["seed"], dataset_name, tl_model_folder
             )
-            model.load_weights(weights_path).expect_partial()
+            tl_weights_path = os.path.join(saved_path, "tl_model")
+            tl_dataset_path = os.path.join(saved_path, "tl_dataset")
+            model.load_weights(tl_weights_path).expect_partial()
             tlds.append(
                 (
                     label,

--- a/training/train_choicenet_v1.py
+++ b/training/train_choicenet_v1.py
@@ -4,6 +4,7 @@ import csv
 import json
 import math
 import os
+from collections.abc import Iterable
 from typing import TypeAlias
 
 import matplotlib.collections
@@ -22,17 +23,11 @@ from models.core import ChoiceNetv1, TransferModel
 from training import LOG_DIR, TLDS_DIR
 from training.create_tlds import DEFAULT_CSV_SUMMARY, PLANT_LEAVES_TRAIN_SAVE_DIR
 
-TLDataset: TypeAlias = list[tuple[str, tuple[np.ndarray, np.ndarray], float]]
 
-
-def build_raw_tlds(
+def parse_summary(
     summary_path: str = DEFAULT_CSV_SUMMARY, num_classes: int = DEFAULT_NUM_CLASSES
-) -> TLDataset:
-    """Build a raw version of the transfer-learning dataset."""
-    plants_ft_ds = tf.data.Dataset.load(PLANT_LEAVES_TRAIN_SAVE_DIR)
-    embedded_plants_ft_ds = embed_dataset(plants_ft_ds)
-
-    tlds: TLDataset = []
+) -> Iterable[tf.keras.Model, str, str, float]:
+    """Yield TL model, dataset path, nickname, and accuracy tuples from the summary."""
     with open(summary_path, encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for i, row in enumerate(reader):
@@ -64,13 +59,24 @@ def build_raw_tlds(
             tl_weights_path = os.path.join(saved_path, "tl_model")
             tl_dataset_path = os.path.join(saved_path, "tl_dataset")
             model.load_weights(tl_weights_path).expect_partial()
-            tlds.append(
-                (
-                    label,
-                    (embed_model(model), embedded_plants_ft_ds),
-                    float(row["accuracy"]),
-                )
-            )
+            yield model, tl_dataset_path, label, float(row["accuracy"])
+
+
+TLDataset: TypeAlias = list[tuple[str, tuple[np.ndarray, np.ndarray], float]]
+
+
+def build_raw_tlds(
+    summary_path: str = DEFAULT_CSV_SUMMARY, num_classes: int = DEFAULT_NUM_CLASSES
+) -> TLDataset:
+    """Build a raw version of the transfer-learning dataset."""
+    plants_ft_ds = tf.data.Dataset.load(PLANT_LEAVES_TRAIN_SAVE_DIR)
+    embedded_plants_ft_ds = embed_dataset(plants_ft_ds)
+
+    tlds: TLDataset = []
+    for tl_model, _, ds_nickname, accuracy in parse_summary(summary_path, num_classes):
+        tlds.append(
+            (ds_nickname, (embed_model(tl_model), embedded_plants_ft_ds), accuracy)
+        )
     return tlds
 
 
@@ -134,10 +140,10 @@ def train_test(args: argparse.Namespace) -> None:
         batch_preds = preds[i : i + args.batch_size].squeeze()
         batch_accuracies = test_dataseq.get_accuracies(i)
         for j, (pred, accuracy) in enumerate(zip(batch_preds, batch_accuracies)):
-            label = tlds[i * test_dataseq.batch_size + j][0]
-            all_results[label].append((accuracy, pred))
+            dataset_nickname = tlds[i * test_dataseq.batch_size + j][0]
+            all_results[dataset_nickname].append((accuracy, pred))
             print(
-                f"Example {i}.{j} with label {label}: "
+                f"Example {i}.{j} with nickname {dataset_nickname}: "
                 f"predicted accuracy {pred * 100:.3f}%, "
                 f"actual accuracy {accuracy * 100:.3f}%."
             )

--- a/training/train_choicenet_v2.py
+++ b/training/train_choicenet_v2.py
@@ -1,0 +1,131 @@
+import argparse
+import collections
+
+import matplotlib.collections
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+
+from data.dataset import DEFAULT_BATCH_SIZE, DEFAULT_NUM_CLASSES, DEFAULT_SEED
+from embedding.embed import embed_dataset_resnet50v2, embed_dataset_with_model
+from models.core import ChoiceNetv2
+from training import LOG_DIR
+from training.create_tlds import DEFAULT_CSV_SUMMARY, PLANT_LEAVES_TRAIN_SAVE_DIR
+from training.train_choicenet_v1 import TLDataset, TLDSSequence, parse_summary
+
+
+def build_raw_tlds(
+    summary_path: str = DEFAULT_CSV_SUMMARY, num_classes: int = DEFAULT_NUM_CLASSES
+) -> TLDataset:
+    """Build a raw version of the transfer-learning dataset."""
+    plants_ft_ds = tf.data.Dataset.load(PLANT_LEAVES_TRAIN_SAVE_DIR)
+    embedded_plants_ft_ds = embed_dataset_resnet50v2(plants_ft_ds)
+
+    tlds: TLDataset = []
+    for tl_model, tl_dataset_path, ds_nickname, accuracy in parse_summary(
+        summary_path, num_classes
+    ):
+        if ds_nickname == "rand init":
+            continue  # Skip over rand init, as it has no associated TL dataset
+        embedded_model = embed_dataset_with_model(
+            dataset=tf.data.Dataset.load(tl_dataset_path), model=tl_model
+        )
+        tlds.append((ds_nickname, (embedded_model, embedded_plants_ft_ds), accuracy))
+    return tlds
+
+
+def train_test(args: argparse.Namespace) -> None:
+    tf.random.set_seed(args.seed)
+
+    tlds = build_raw_tlds(summary_path=args.tlds_csv_summary)
+    num_training_ds = int(len(tlds) * (1 - args.validation_split))
+    if num_training_ds >= len(tlds):  # Reuse training ds as test ds
+        training_dataseq = TLDSSequence(tlds, batch_size=args.batch_size)
+        test_dataseq = training_dataseq
+    else:
+        training_dataseq = TLDSSequence(
+            tlds[:num_training_ds], batch_size=args.batch_size
+        )
+        test_dataseq = TLDSSequence(tlds[num_training_ds:], batch_size=args.batch_size)
+
+    model = ChoiceNetv2()
+    model.compile(
+        optimizer=tf.keras.optimizers.Adam(learning_rate=args.learning_rate),
+        loss="mse",
+        metrics=["mse"],
+    )
+
+    model.fit(training_dataseq)
+    preds: np.ndarray = model.predict(test_dataseq)
+
+    all_results: dict[str, list[tuple[float, float]]] = collections.defaultdict(list)
+    for i in range(len(test_dataseq)):
+        batch_preds = preds[i : i + args.batch_size].squeeze()
+        batch_accuracies = test_dataseq.get_accuracies(i)
+        for j, (pred, accuracy) in enumerate(zip(batch_preds, batch_accuracies)):
+            dataset_nickname = tlds[i * test_dataseq.batch_size + j][0]
+            all_results[dataset_nickname].append((accuracy, pred))
+            print(
+                f"Example {i}.{j} with nickname {dataset_nickname}: "
+                f"predicted accuracy {pred * 100:.3f}%, "
+                f"actual accuracy {accuracy * 100:.3f}%."
+            )
+
+    fig, ax = plt.subplots()
+    scatter_plots: dict[str, matplotlib.collections.Collection] = {
+        label: ax.scatter(*list(zip(*data)), label=f"{label} (x{len(data)})")
+        for label, data in all_results.items()
+    }
+    x_lim, y_lim = ax.get_xlim(), ax.get_ylim()
+    ax.plot([0, 1], [0, 1], color="grey", label="unit line")
+    ax.set_xlim(x_lim)
+    ax.set_ylim(y_lim)
+    ax.set_xlabel("Actual Accuracy")
+    ax.set_ylabel("Predicted Accuracy")
+    ax.grid()
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig("choicenet_v2_performance.png")
+    _ = 0  # Debug here
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train ChoiceNet v1")
+    parser.add_argument(
+        "-s", "--seed", type=int, default=DEFAULT_SEED, help="random seed"
+    )
+    parser.add_argument(
+        "--run_nickname",
+        type=str,
+        default="foo",
+        help="nickname for saving logs/models",
+    )
+    parser.add_argument(
+        "--tlds_csv_summary",
+        type=str,
+        default=DEFAULT_CSV_SUMMARY,
+        help="transfer learning dataset summary CSV file location",
+    )
+    parser.add_argument(
+        "--learning_rate", type=float, default=1e-3, help="learning rate"
+    )
+    parser.add_argument(
+        "--validation_split",
+        type=float,
+        default=0.0,
+        help="fraction of transfer learning datasets to use for validation",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help="batch size for training and prediction",
+    )
+    parser.add_argument(
+        "--log_dir", type=str, default=LOG_DIR, help="log base directory"
+    )
+    train_test(parser.parse_args())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Adds new embedding functions for ChoiceNet v2
    - Renames v2 embeddings and better documents
- Makes `TransferModel` able to have its top included or excluded
- Decomposes ChoiceNet v1 training to have DRY v2 training via `parse_summary` function
- Adds ChoiceNet v2 training