### PR TITLE
Multiple Invocation TLDS, Multiple Epochs of TLDS Training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,6 +288,5 @@ models/saved_models/
 
 # TLDS
 training/tlds/
-training/tlds_summary.csv
-training/choicenet_v1_performance.png
-training/choicenet_v2_performance.png
+training/tlds_summary*.csv
+training/choicenet_v*_performance.png

--- a/data/dataset.py
+++ b/data/dataset.py
@@ -87,6 +87,7 @@ def get_random_datasets(
     full_labels = get_all_labels(dataset)
     rng = np.random.default_rng(seed)
     labels = rng.choice(full_labels, size=(num_ds, num_classes), replace=False)
+    labels.sort(axis=1)  # Sort rows by increasing class index
     return [
         (
             _batch_take(

--- a/data/dataset.py
+++ b/data/dataset.py
@@ -213,6 +213,7 @@ def get_plant_diseases_datasets(
 PLANT_LEAVES_REL_PATH = "plant-leaves/Plants_2"
 PLANT_LEAVES_TRAIN = os.path.join(DATA_DIR, *PLANT_LEAVES_REL_PATH.split("/"), "train")
 PLANT_LEAVES_VAL = os.path.join(DATA_DIR, *PLANT_LEAVES_REL_PATH.split("/"), "valid")
+PLANT_LEAVES_TEST = os.path.join(DATA_DIR, *PLANT_LEAVES_REL_PATH.split("/"), "test")
 
 
 def get_plant_leaves_datasets(
@@ -231,14 +232,21 @@ def get_plant_leaves_datasets(
             NOTE: for labels, indices correspond with ID, values correspond
             with string labels.
     """
-    return get_image_dataset_from_directory(
+    train_ds, val_ds, labels = get_image_dataset_from_directory(
         train_dir=PLANT_LEAVES_TRAIN,
         val_dir=PLANT_LEAVES_VAL,
         num_train_batch=num_train_batch,
-        num_val_batch=num_val_batch,
         seed=seed,
         **from_dir_kwargs,
     )
+    from_dir_kwargs = {"seed": seed} | from_dir_kwargs
+    # Since the normal validation dataset is small, augment with the test dataset
+    val_ds_aug = val_ds.concatenate(
+        tf.keras.utils.image_dataset_from_directory(
+            PLANT_LEAVES_TEST, **from_dir_kwargs
+        )
+    )
+    return train_ds, val_ds_aug.take(num_val_batch), labels
 
 
 BIRD_SPECIES_REL_PATH = "bird-species"

--- a/models/core.py
+++ b/models/core.py
@@ -158,7 +158,7 @@ class ChoiceNetv2(tf.keras.Model):
     def call(self, inputs: Annotated[Sequence[tf.Tensor], 2], training=None, mask=None):
         reduced_tl_model_weights = self.weights_reduce(inputs[0])
         reduced_ft_dataset_weights = self.dataset_reduce(inputs[1])
-        x = self.flatten(reduced_tl_model_weights - reduced_ft_dataset_weights)
+        x = self.flatten(reduced_tl_model_weights + reduced_ft_dataset_weights)
         x = self.dense1(x)
         x = self.dropout(x, training=training)
         return self.dense2(x)

--- a/training/create_tlds.py
+++ b/training/create_tlds.py
@@ -191,9 +191,9 @@ def train(args: argparse.Namespace) -> None:
     )
     for i, (dataset_name, dataset, labels) in enumerate(
         [("cifar100", *v) for v in cifar100_random_datasets]
-        + [("imagenet_resized/32x32", *v) for v in imagenet_random_datasets]
         + [("plant_village", *v) for v in plants_village_datasets]
         + [("bird-species", *v) for v in birds_random_datasets]
+        + [("imagenet_resized/32x32", *v) for v in imagenet_random_datasets]
     ):
         labels_name = str(list(labels)).replace(" ", "")
         # Keras can't handle [] per https://github.com/keras-team/keras/issues/17265
@@ -297,7 +297,7 @@ def main() -> None:
     parser.add_argument(
         "--ft_num_batches",
         type=int,
-        default=math.ceil(2e3 / DEFAULT_BATCH_SIZE),
+        default=math.ceil(1.5e3 / DEFAULT_BATCH_SIZE),  # Keep small to emphasize TL
         help="number of batches to have in the fine tuning dataset",
     )
     parser.add_argument(
@@ -309,7 +309,7 @@ def main() -> None:
     parser.add_argument(
         "--test_num_batches",
         type=int,
-        default=math.ceil(1e3 / DEFAULT_BATCH_SIZE),
+        default=math.ceil(2e3 / DEFAULT_BATCH_SIZE),
         help="number of batches to have in the test dataset",
     )
     parser.add_argument("--num_epochs", type=int, default=15, help="number of epochs")

--- a/training/create_tlds.py
+++ b/training/create_tlds.py
@@ -37,6 +37,8 @@ PLANT_LEAVES_TRAIN_SAVE_DIR = os.path.join(
 BIRD_SPECIES_TRAIN_SAVE_DIR = os.path.join(
     DATA_DIR, *BIRD_SPECIES_REL_PATH.split("/"), "train_ds_export"
 )
+FINE_TUNE_DS_SAVE_NAME = "ft"
+TEST_DS_SAVE_NAME = "test"
 
 
 def preprocess_standardize(
@@ -87,13 +89,14 @@ def preprocess_ds_save(
     ft_ds: tf.data.Dataset,
     test_ds: tf.data.Dataset,
     preprocessor: Callable[[tf.data.Dataset], tf.data.Dataset],
-    ft_ds_save_dir: str,
+    save_dir: str,
 ) -> tuple[tf.data.Dataset, tf.data.Dataset]:
-    """Preprocess both fine-tuning and test datasets, saving the fine-tuning dataset."""
+    """Preprocess and save both fine-tuning and test datasets."""
     ft_ds, test_ds = (preprocessor(ds) for ds in (ft_ds, test_ds))
-    if os.path.exists(ft_ds_save_dir):
-        shutil.rmtree(ft_ds_save_dir)  # Only persist one dataset
-    ft_ds.save(ft_ds_save_dir)
+    if os.path.exists(save_dir):
+        shutil.rmtree(save_dir)  # Only persist one copy
+    ft_ds.save(os.path.join(save_dir, FINE_TUNE_DS_SAVE_NAME))
+    test_ds.save(os.path.join(save_dir, TEST_DS_SAVE_NAME))
     return ft_ds, test_ds
 
 
@@ -104,24 +107,32 @@ def train(args: argparse.Namespace) -> None:
         csv.writer(f).writerow(["dataset", "seed", "labels", "accuracy"])
 
     dataset_config = DATASET_CONFIGS["imagenet_resized/32x32"]
-    plants_ft_ds, plants_test_ds, plants_labels = get_plant_leaves_datasets(
-        num_train_batch=args.ft_num_batches,
-        num_val_batch=args.test_num_batches,
-        seed=args.seed,
-        batch_size=args.batch_size,
-        image_size=dataset_config.image_shape[:-1],
+
+    if not os.path.exists(PLANT_LEAVES_TRAIN_SAVE_DIR):
+        plants_ft_ds, plants_test_ds, plant_labels = get_plant_leaves_datasets(
+            num_train_batch=args.ft_num_batches,
+            num_val_batch=args.test_num_batches,
+            seed=args.seed,
+            batch_size=args.batch_size,
+            image_size=dataset_config.image_shape[:-1],
+        )
+        plants_ft_ds, plants_test_ds = preprocess_ds_save(
+            plants_ft_ds,
+            plants_test_ds,
+            preprocessor=partial(preprocess_standardize, num_classes=len(plant_labels)),
+            save_dir=PLANT_LEAVES_TRAIN_SAVE_DIR,
+        )
+    # Reload in fine-tuning and test datasets as a speed optimization
+    plants_ft_ds = tf.data.Dataset.load(
+        os.path.join(PLANT_LEAVES_TRAIN_SAVE_DIR, FINE_TUNE_DS_SAVE_NAME)
     )
-    plants_ft_ds, plants_test_ds = preprocess_ds_save(
-        plants_ft_ds,
-        plants_test_ds,
-        preprocessor=partial(preprocess_standardize, num_classes=len(plants_labels)),
-        ft_ds_save_dir=PLANT_LEAVES_TRAIN_SAVE_DIR,
+    plants_test_ds = tf.data.Dataset.load(
+        os.path.join(PLANT_LEAVES_TRAIN_SAVE_DIR, TEST_DS_SAVE_NAME)
     )
-    # Reload in fine-tuning dataset as a speed optimization
-    plants_ft_ds = tf.data.Dataset.load(PLANT_LEAVES_TRAIN_SAVE_DIR)
+    num_ft_classes = DATASET_CONFIGS["plant-leaves"].num_classes
 
     def compute_accuracy(tl_model: TransferModel) -> float:
-        new_model = tl_model.clone(new_num_classes=len(plants_labels))
+        new_model = tl_model.clone(new_num_classes=num_ft_classes)
         new_model.layer1.trainable = False
         new_model.layer2.trainable = False
 

--- a/training/train_choicenet_v1.py
+++ b/training/train_choicenet_v1.py
@@ -4,7 +4,8 @@ import csv
 import json
 import math
 import os
-from collections.abc import Iterable
+import random
+from collections.abc import Iterable, Mapping
 from typing import TypeAlias
 
 import matplotlib.collections
@@ -21,13 +22,22 @@ from data.dataset import (
 from embedding.embed import embed_dataset_pca, embed_model
 from models.core import ChoiceNetv1, TransferModel
 from training import LOG_DIR, TLDS_DIR
-from training.create_tlds import DEFAULT_CSV_SUMMARY, PLANT_LEAVES_TRAIN_SAVE_DIR
+from training.create_tlds import (
+    DEFAULT_CSV_SUMMARY,
+    FINE_TUNE_DS_SAVE_NAME,
+    PLANT_LEAVES_TRAIN_SAVE_DIR,
+)
+
+TLDatasetKey: TypeAlias = tuple[str, str, str]
+TLDataset: TypeAlias = dict[
+    TLDatasetKey, tuple[str, tuple[np.ndarray, np.ndarray], float]
+]
 
 
 def parse_summary(
     summary_path: str = DEFAULT_CSV_SUMMARY, num_classes: int = DEFAULT_NUM_CLASSES
-) -> Iterable[tf.keras.Model, str, str, float]:
-    """Yield TL model, dataset path, nickname, and accuracy tuples from the summary."""
+) -> Iterable[tf.keras.Model, str, tuple[str, str], float]:
+    """Yield TL model, dataset path, (ds name, ds category), and accuracy tuples."""
     with open(summary_path, encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for i, row in enumerate(reader):
@@ -43,26 +53,26 @@ def parse_summary(
                 if dataset_name == "cifar100" or dataset_name.startswith(
                     "imagenet_resized"
                 ):
-                    label = "random"
+                    key: TLDatasetKey = (dataset_name, "random", row["labels"])
                 elif dataset_name == "bird-species":
-                    label = "dissimilar"
+                    key = (dataset_name, "dissimilar", row["labels"])
                 elif dataset_name == "plant_village":
-                    label = "similar"
+                    key = (dataset_name, "similar", row["labels"])
                 else:
                     raise NotImplementedError(f"Unspecified dataset {dataset_name}.")
             except json.decoder.JSONDecodeError:
                 tl_model_folder = row["labels"]
-                label = "rand init"
+                key = (dataset_name, "rand init", row["labels"])
             saved_path = os.path.join(
                 TLDS_DIR, row["seed"], dataset_name, tl_model_folder
             )
             tl_weights_path = os.path.join(saved_path, "tl_model")
             tl_dataset_path = os.path.join(saved_path, "tl_dataset")
             model.load_weights(tl_weights_path).expect_partial()
-            yield model, tl_dataset_path, label, float(row["accuracy"])
+            yield model, tl_dataset_path, key, float(row["accuracy"])
 
 
-LABEL_TO_COLOR: dict[str, str] = {
+CATEGORY_TO_COLOR: dict[str, str] = {
     "dissimilar": "red",
     "random": "orange",
     "similar": "green",
@@ -70,22 +80,28 @@ LABEL_TO_COLOR: dict[str, str] = {
 }
 
 
-TLDataset: TypeAlias = list[tuple[str, tuple[np.ndarray, np.ndarray], float]]
+def shuffle_mapping(d: Mapping) -> dict:
+    """Shuffle the input mapping, not in place."""
+    as_tuple = list(d.items())
+    random.shuffle(as_tuple)
+    return dict(as_tuple)
 
 
 def build_raw_tlds(
     summary_path: str = DEFAULT_CSV_SUMMARY, num_classes: int = DEFAULT_NUM_CLASSES
 ) -> TLDataset:
-    """Build a raw version of the transfer-learning dataset."""
-    plants_ft_ds = tf.data.Dataset.load(PLANT_LEAVES_TRAIN_SAVE_DIR)
+    """Build a raw version of the transfer-learning dataset, with shuffling."""
+    plants_ft_ds = tf.data.Dataset.load(
+        os.path.join(PLANT_LEAVES_TRAIN_SAVE_DIR, FINE_TUNE_DS_SAVE_NAME)
+    )
     embedded_plants_ft_ds = embed_dataset_pca(plants_ft_ds)
 
-    tlds: TLDataset = []
-    for tl_model, _, ds_nickname, accuracy in parse_summary(summary_path, num_classes):
-        tlds.append(
-            (ds_nickname, (embed_model(tl_model), embedded_plants_ft_ds), accuracy)
-        )
-    return tlds
+    tlds: TLDataset = {}
+    for tl_model, _, key, accuracy in parse_summary(summary_path, num_classes):
+        # Use of the key ensures that if we have a duplicated TL dataset, that
+        # we use the most recently-saved one
+        tlds[key] = (key[1], (embed_model(tl_model), embedded_plants_ft_ds), accuracy)
+    return shuffle_mapping(tlds)
 
 
 class TLDSSequence(tf.keras.utils.Sequence):
@@ -97,7 +113,8 @@ class TLDSSequence(tf.keras.utils.Sequence):
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Vertically stack embeddings and accuracies into stacked ndarrays."""
         flattened = [
-            (x[0][np.newaxis, :], x[1][np.newaxis, :], y) for (_, x, y) in dataset
+            (x[0][np.newaxis, :], x[1][np.newaxis, :], y)
+            for (_, x, y) in dataset.values()
         ]
         x0, x1, y = zip(*flattened)
         return np.vstack(x0), np.vstack(x1), np.array(y)
@@ -168,22 +185,22 @@ def train_test(args: argparse.Namespace) -> None:
         batch_preds = preds[i : i + args.batch_size].squeeze()
         batch_accuracies = test_dataseq.get_accuracies(i)
         for j, (pred, accuracy) in enumerate(zip(batch_preds, batch_accuracies)):
-            dataset_nickname = tlds[i * test_dataseq.batch_size + j][0]
-            all_results[dataset_nickname].append((accuracy, pred))
+            dataset_category = list(tlds)[i * test_dataseq.batch_size + j][1]
+            all_results[dataset_category].append((accuracy, pred))
             print(
-                f"Example {i}.{j} with nickname {dataset_nickname}: "
+                f"Example {i}.{j} with category {dataset_category}: "
                 f"predicted accuracy {pred * 100:.3f}%, "
                 f"actual accuracy {accuracy * 100:.3f}%."
             )
 
     fig, ax = plt.subplots()
     scatter_plots: dict[str, matplotlib.collections.Collection] = {
-        label: ax.scatter(
+        category: ax.scatter(
             *list(zip(*data)),
-            label=f"{label} (x{len(data)})",
-            color=LABEL_TO_COLOR[label],
+            label=f"{category} (x{len(data)})",
+            color=CATEGORY_TO_COLOR[category],
         )
-        for label, data in all_results.items()
+        for category, data in all_results.items()
     }
     x_lim, y_lim = ax.get_xlim(), ax.get_ylim()
     ax.plot([0, 1], [0, 1], color="grey", label="unit line")

--- a/training/train_choicenet_v1.py
+++ b/training/train_choicenet_v1.py
@@ -62,6 +62,14 @@ def parse_summary(
             yield model, tl_dataset_path, label, float(row["accuracy"])
 
 
+LABEL_TO_COLOR: dict[str, str] = {
+    "dissimilar": "red",
+    "random": "orange",
+    "similar": "green",
+    "rand init": "grey",
+}
+
+
 TLDataset: TypeAlias = list[tuple[str, tuple[np.ndarray, np.ndarray], float]]
 
 
@@ -159,10 +167,13 @@ def train_test(args: argparse.Namespace) -> None:
 
     fig, ax = plt.subplots()
     scatter_plots: dict[str, matplotlib.collections.Collection] = {
-        label: ax.scatter(*list(zip(*data)), label=f"{label} (x{len(data)})")
+        label: ax.scatter(
+            *list(zip(*data)),
+            label=f"{label} (x{len(data)})",
+            color=LABEL_TO_COLOR[label],
+        )
         for label, data in all_results.items()
     }
-    scatter_plots["rand init"].set_color("grey")
     x_lim, y_lim = ax.get_xlim(), ax.get_ylim()
     ax.plot([0, 1], [0, 1], color="grey", label="unit line")
     ax.set_xlim(x_lim)

--- a/training/train_choicenet_v1.py
+++ b/training/train_choicenet_v1.py
@@ -119,6 +119,11 @@ class TLDSSequence(tf.keras.utils.Sequence):
         return self.arrays[2][bslice]
 
 
+MAX_NUM_EPOCHS = 150
+EARLY_STOPPING_PATIENCE = 20
+LEARNING_RATE = 1e-4
+
+
 def train_test(args: argparse.Namespace) -> None:
     tf.random.set_seed(args.seed)
 
@@ -145,9 +150,15 @@ def train_test(args: argparse.Namespace) -> None:
         epochs=args.num_epochs,
         callbacks=[
             tf.keras.callbacks.TensorBoard(
-                log_dir=os.path.join(LOG_DIR, "choicenet", str(args.seed)),
+                log_dir=os.path.join(LOG_DIR, "choicenet_v1", str(args.seed)),
                 histogram_freq=1,
-            )
+            ),
+            tf.keras.callbacks.EarlyStopping(
+                monitor="loss",
+                patience=EARLY_STOPPING_PATIENCE,
+                restore_best_weights=True,
+                verbose=1,
+            ),
         ],
     )
     preds: np.ndarray = model.predict(test_dataseq)
@@ -205,12 +216,12 @@ def main() -> None:
         help="transfer learning dataset summary CSV file location",
     )
     parser.add_argument(
-        "--learning_rate", type=float, default=1e-3, help="learning rate"
+        "--learning_rate", type=float, default=LEARNING_RATE, help="learning rate"
     )
     parser.add_argument(
         "--num_epochs",
         type=int,
-        default=15,
+        default=MAX_NUM_EPOCHS,
         help="number of epochs for training ChoiceNet",
     )
     parser.add_argument(

--- a/training/train_choicenet_v1.py
+++ b/training/train_choicenet_v1.py
@@ -28,6 +28,7 @@ from training.create_tlds import (
     PLANT_LEAVES_TRAIN_SAVE_DIR,
 )
 
+# Key values are (dataset name, category, labels)
 TLDatasetKey: TypeAlias = tuple[str, str, str]
 TLDataset: TypeAlias = dict[
     TLDatasetKey, tuple[str, tuple[np.ndarray, np.ndarray], float]
@@ -36,8 +37,8 @@ TLDataset: TypeAlias = dict[
 
 def parse_summary(
     summary_path: str = DEFAULT_CSV_SUMMARY, num_classes: int = DEFAULT_NUM_CLASSES
-) -> Iterable[tf.keras.Model, str, tuple[str, str], float]:
-    """Yield TL model, dataset path, (ds name, ds category), and accuracy tuples."""
+) -> Iterable[tf.keras.Model, str, TLDatasetKey, float]:
+    """Yield TL model, dataset path, dataset key, and accuracy tuples."""
     with open(summary_path, encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for i, row in enumerate(reader):

--- a/training/train_choicenet_v2.py
+++ b/training/train_choicenet_v2.py
@@ -12,7 +12,12 @@ from embedding.embed import embed_dataset_resnet50v2, embed_dataset_with_model
 from models.core import ChoiceNetv2
 from training import LOG_DIR
 from training.create_tlds import DEFAULT_CSV_SUMMARY, PLANT_LEAVES_TRAIN_SAVE_DIR
-from training.train_choicenet_v1 import TLDataset, TLDSSequence, parse_summary
+from training.train_choicenet_v1 import (
+    LABEL_TO_COLOR,
+    TLDataset,
+    TLDSSequence,
+    parse_summary,
+)
 
 
 def build_raw_tlds(
@@ -83,7 +88,11 @@ def train_test(args: argparse.Namespace) -> None:
 
     fig, ax = plt.subplots()
     scatter_plots: dict[str, matplotlib.collections.Collection] = {
-        label: ax.scatter(*list(zip(*data)), label=f"{label} (x{len(data)})")
+        label: ax.scatter(
+            *list(zip(*data)),
+            label=f"{label} (x{len(data)})",
+            color=LABEL_TO_COLOR[label],
+        )
         for label, data in all_results.items()
     }
     x_lim, y_lim = ax.get_xlim(), ax.get_ylim()

--- a/training/train_choicenet_v2.py
+++ b/training/train_choicenet_v2.py
@@ -13,7 +13,10 @@ from models.core import ChoiceNetv2
 from training import LOG_DIR
 from training.create_tlds import DEFAULT_CSV_SUMMARY, PLANT_LEAVES_TRAIN_SAVE_DIR
 from training.train_choicenet_v1 import (
+    EARLY_STOPPING_PATIENCE,
     LABEL_TO_COLOR,
+    LEARNING_RATE,
+    MAX_NUM_EPOCHS,
     TLDataset,
     TLDSSequence,
     parse_summary,
@@ -66,9 +69,15 @@ def train_test(args: argparse.Namespace) -> None:
         epochs=args.num_epochs,
         callbacks=[
             tf.keras.callbacks.TensorBoard(
-                log_dir=os.path.join(LOG_DIR, "choicenet", str(args.seed)),
+                log_dir=os.path.join(LOG_DIR, "choicenet_v2", str(args.seed)),
                 histogram_freq=1,
-            )
+            ),
+            tf.keras.callbacks.EarlyStopping(
+                monitor="loss",
+                patience=EARLY_STOPPING_PATIENCE,
+                restore_best_weights=True,
+                verbose=1,
+            ),
         ],
     )
     preds: np.ndarray = model.predict(test_dataseq)
@@ -126,12 +135,12 @@ def main() -> None:
         help="transfer learning dataset summary CSV file location",
     )
     parser.add_argument(
-        "--learning_rate", type=float, default=1e-3, help="learning rate"
+        "--learning_rate", type=float, default=LEARNING_RATE, help="learning rate"
     )
     parser.add_argument(
         "--num_epochs",
         type=int,
-        default=15,
+        default=MAX_NUM_EPOCHS,
         help="number of epochs for training ChoiceNet",
     )
     parser.add_argument(


### PR DESCRIPTION
- Allows multiple invocations to `create_tlds` to build a bigger dataset
    - Sorting the class indices in increasing order
    - Saving the fine-tuning and test datasets to avoid changing across invocations
    - Made training scripts keep only the last subset that is duplicated
    - Compressed lines in `.gitignore` to allow multiple summaries to be ignored
- Better training of ChoiceNet v1/v2
    - Training for 150 epochs at a smaller learning rate, instead of 1 at a higher learning rate
    - Added `EarlyStopping` callback with patience of 20 epochs
    - Made ChoiceNet v2 use addition instead of subtraction
    - 2X the test dataset size by combining `plant-leaves` validation and test subsets
        - Increased test dataset size accordingly
- Better plotting of ChoiceNet v1/v2
    - Decreased fine-tuning dataset size to emphasize pre-training
    - Sharing `CATEGORY_TO_COLOR` mapping to have same-color points
- Made ImageNet be the last portion of TLDS creation, since it's the slowest